### PR TITLE
perf: file tree lazy-load directories on expand

### DIFF
--- a/packages/agent/src/client.ts
+++ b/packages/agent/src/client.ts
@@ -744,10 +744,8 @@ export class AgentClient extends EventEmitter {
       'node_modules', '.git', '.next', 'dist', 'build', '.turbo',
       '__pycache__', '.venv', 'venv', '.DS_Store', 'coverage',
     ]);
-    const MAX_DEPTH = 3;
 
-    const scan = async (dir: string, depth: number): Promise<FileTreeItem[]> => {
-      if (depth > MAX_DEPTH) return [];
+    const scanSingleLevel = async (dir: string): Promise<FileTreeItem[]> => {
       try {
         const entries = await fs.readdir(dir, { withFileTypes: true });
         const items: FileTreeItem[] = [];
@@ -755,8 +753,7 @@ export class AgentClient extends EventEmitter {
           if (IGNORED.has(entry.name) || entry.name.startsWith('.')) continue;
           const fullPath = path.join(dir, entry.name);
           if (entry.isDirectory()) {
-            const children = await scan(fullPath, depth + 1);
-            items.push({ name: entry.name, path: fullPath, type: 'directory', children });
+            items.push({ name: entry.name, path: fullPath, type: 'directory' });
           } else {
             items.push({ name: entry.name, path: fullPath, type: 'file' });
           }
@@ -771,12 +768,15 @@ export class AgentClient extends EventEmitter {
       }
     };
 
+    const targetDir = data.dir_path || data.project_path;
+
     try {
-      const tree = await scan(data.project_path, 0);
+      const items = await scanSingleLevel(targetDir);
       this.socket?.emit(SocketEvents.FILES_LIST, {
         machine_id: data.machine_id,
         project_path: data.project_path,
-        files: tree,
+        dir_path: data.dir_path,
+        files: items,
         request_id: data.request_id,
       });
     } catch (error) {
@@ -784,6 +784,7 @@ export class AgentClient extends EventEmitter {
       this.socket?.emit(SocketEvents.FILES_LIST, {
         machine_id: data.machine_id,
         project_path: data.project_path,
+        dir_path: data.dir_path,
         files: [],
         request_id: data.request_id,
       });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -230,6 +230,7 @@ export interface HistoryMessage {
 export interface ListFilesRequest {
   machine_id: string;
   project_path: string;
+  dir_path?: string; // 懒加载：指定要展开的子目录路径，不传则扫描根目录
   request_id?: string;
 }
 

--- a/packages/web/src/components/workspace/Sidebar.tsx
+++ b/packages/web/src/components/workspace/Sidebar.tsx
@@ -77,19 +77,29 @@ interface FileTreeNodeProps {
   item: FileTreeItem;
   depth: number;
   currentFile: string | null;
+  loadingDirs: Set<string>;
   onFileClick: (path: string) => void;
   onFileDoubleClick?: (path: string) => void;
+  onExpandDir: (dirPath: string) => void;
 }
 
-const FileTreeNode: React.FC<FileTreeNodeProps> = ({ item, depth, currentFile, onFileClick, onFileDoubleClick }) => {
-  const [expanded, setExpanded] = useState(depth === 0);
+const FileTreeNode: React.FC<FileTreeNodeProps> = ({ item, depth, currentFile, loadingDirs, onFileClick, onFileDoubleClick, onExpandDir }) => {
+  const [expanded, setExpanded] = useState(false);
   const isActive = currentFile === item.path;
 
+  const handleToggle = useCallback(() => {
+    if (!expanded && item.children === undefined) {
+      onExpandDir(item.path);
+    }
+    setExpanded(!expanded);
+  }, [expanded, item.path, item.children, onExpandDir]);
+
   if (item.type === 'directory') {
+    const isLoading = loadingDirs.has(item.path);
     return (
       <div>
         <button
-          onClick={() => setExpanded(!expanded)}
+          onClick={handleToggle}
           className="w-full text-left flex items-center gap-1.5 py-0.5 px-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors group"
           style={{ paddingLeft: `${depth * 12 + 4}px` }}
         >
@@ -105,15 +115,28 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = ({ item, depth, currentFile, o
             />
           </svg>
           <span className="text-gray-700 dark:text-gray-200 text-xs truncate">{item.name}</span>
+          {isLoading && (
+            <svg className="w-3 h-3 text-gray-400 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          )}
         </button>
+        {expanded && isLoading && (
+          <div className="text-gray-400 dark:text-gray-500 text-xs text-center py-1" style={{ paddingLeft: `${(depth + 1) * 12 + 4}px` }}>
+            ...
+          </div>
+        )}
         {expanded && item.children?.map((child) => (
           <FileTreeNode
             key={child.path}
             item={child}
             depth={depth + 1}
             currentFile={currentFile}
+            loadingDirs={loadingDirs}
             onFileClick={onFileClick}
             onFileDoubleClick={onFileDoubleClick}
+            onExpandDir={onExpandDir}
           />
         ))}
       </div>
@@ -162,6 +185,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const projectName = projectPath.split(/[/\\]/).pop() || projectPath;
   const [tab, setTab] = useState<SidebarTab>('sessions');
   const { t } = useTranslation();
+
+  const loadingDirs = useSessionStore((s) => s.loadingDirs);
+  const expandDir = useSessionStore((s) => s.expandDir);
+
+  const handleExpandDir = useCallback((dirPath: string) => {
+    if (machineId && projectPath) {
+      expandDir(machineId, projectPath, dirPath);
+    }
+  }, [machineId, projectPath, expandDir]);
 
   const [showNewSessionHint, setShowNewSessionHint] = useState(false);
 
@@ -398,8 +430,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       item={item}
                       depth={0}
                       currentFile={currentFile}
+                      loadingDirs={loadingDirs}
                       onFileClick={onFileClick}
                       onFileDoubleClick={onFileDoubleClick}
+                      onExpandDir={handleExpandDir}
                     />
                   ))}
                 </div>

--- a/packages/web/src/lib/socket.ts
+++ b/packages/web/src/lib/socket.ts
@@ -432,11 +432,12 @@ class SocketManager {
   /**
    * 获取项目文件列表
    */
-  listFiles(machineId: string, projectPath: string): void {
+  listFiles(machineId: string, projectPath: string, dirPath?: string): void {
     if (!this.socket?.connected) return;
     this.socket.emit(SocketEvents.LIST_FILES, {
       machine_id: machineId,
       project_path: projectPath,
+      dir_path: dirPath,
     });
   }
 

--- a/packages/web/src/stores/sessionStore.ts
+++ b/packages/web/src/stores/sessionStore.ts
@@ -56,6 +56,7 @@ interface SessionState {
   isResumedSession: boolean;
   fileTree: FileTreeItem[];
   isLoadingFiles: boolean;
+  loadingDirs: Set<string>; // 正在加载子目录的路径集合
   customCommands: SlashCommandItem[];
   pendingSessionRequestId: string | null; // 用于验证 SESSION_STARTED 是否是自己发起的
 
@@ -86,6 +87,7 @@ interface SessionState {
   setCurrentSession: (session: SessionInfo | null) => void;
   fetchSessionHistory: (machineId: string, projectPath: string) => void;
   fetchFileTree: (machineId: string, projectPath: string) => void;
+  expandDir: (machineId: string, projectPath: string, dirPath: string) => void;
   fetchCommands: (machineId: string, projectPath: string) => void;
   clearError: () => void;
   reset: () => void;
@@ -133,6 +135,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   isResumedSession: false,
   fileTree: [],
   isLoadingFiles: false,
+  loadingDirs: new Set(),
   customCommands: [],
   pendingSessionRequestId: null,
 
@@ -262,6 +265,14 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   fetchFileTree: (machineId: string, projectPath: string) => {
     set({ isLoadingFiles: true });
     socketManager.listFiles(machineId, projectPath);
+  },
+
+  // 懒加载：展开指定子目录
+  expandDir: (machineId: string, projectPath: string, dirPath: string) => {
+    const { loadingDirs } = useSessionStore.getState();
+    if (loadingDirs.has(dirPath)) return; // 防止重复请求
+    set({ loadingDirs: new Set([...loadingDirs, dirPath]) });
+    socketManager.listFiles(machineId, projectPath, dirPath);
   },
 
   // 获取斜杠命令列表
@@ -695,11 +706,37 @@ export const subscribeToSessionEvents = (): (() => void) => {
   // 文件列表
   unsubscribers.push(
     socketManager.on(SocketEvents.FILES_LIST, (data: unknown) => {
-      const typedData = data as { machine_id: string; project_path: string; files: FileTreeItem[] };
+      const typedData = data as { machine_id: string; project_path: string; dir_path?: string; files: FileTreeItem[] };
       const store = useSessionStore.getState();
       // 只处理当前会话的数据
-      if (store.currentSession?.machineId === typedData.machine_id &&
-          store.currentSession?.projectPath === typedData.project_path) {
+      if (store.currentSession?.machineId !== typedData.machine_id ||
+          store.currentSession?.projectPath !== typedData.project_path) {
+        return;
+      }
+
+      if (typedData.dir_path) {
+        // 懒加载模式：更新指定目录的 children
+        const updateChildren = (items: FileTreeItem[]): FileTreeItem[] =>
+          items.map(item => {
+            if (item.path === typedData.dir_path) {
+              return { ...item, children: typedData.files || [] };
+            }
+            if (item.children) {
+              return { ...item, children: updateChildren(item.children) };
+            }
+            return item;
+          });
+
+        const { loadingDirs } = store;
+        const next = new Set(loadingDirs);
+        next.delete(typedData.dir_path);
+
+        useSessionStore.setState({
+          fileTree: updateChildren(store.fileTree),
+          loadingDirs: next,
+        });
+      } else {
+        // 根目录模式：替换整个 fileTree
         useSessionStore.setState({
           fileTree: typedData.files || [],
           isLoadingFiles: false,


### PR DESCRIPTION
## Summary
- File tree now loads only the root directory initially; sub-directories are fetched on expand
- Removes the fixed `MAX_DEPTH=3` full recursive scan, replacing it with single-level `scanSingleLevel()`
- Adds `dir_path` parameter to `ListFilesRequest` for requesting specific sub-directories
- Shows loading spinner while fetching directory contents

Closes #6

## Test plan
- [ ] Open a project with many files — only root-level items should load initially
- [ ] Click a directory to expand — children should load with a brief spinner
- [ ] Verify collapsed directories that haven't been expanded don't show children
- [ ] Verify already-expanded directories keep their children when collapsing/re-expanding
- [ ] Test on a large project (1000+ files) for performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)