### PR TITLE
fix: content missing after tool execution in chat mode (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be documented in this file.
 - 修复 Agent 下载附件失败的问题：相对路径的签名 URL 未拼接服务器地址
 - Fix web UI stuck in "generating" state when SDK doesn't emit result message
 - 修复 SDK 未发送 result 消息时 Web UI 卡在"生成中"状态的问题
+- Fix content missing after tool execution: handle text blocks in `assistant` messages and prevent double `complete` emission ([#13](https://github.com/markbruce/claude-code-remote/issues/13))
+- 修复工具执行后内容丢失：处理 `assistant` 消息中的 text 块，防止 `complete` 事件重复发送清空 tokenUsage
 
 ### Changed / 变更
 

--- a/packages/agent/src/sdk-session.ts
+++ b/packages/agent/src/sdk-session.ts
@@ -107,6 +107,8 @@ export class SdkSession extends EventEmitter {
   private queryInstance: Query | null = null;
   private abortController = new AbortController();
   private pendingPermissions = new Map<string, PermissionResolver>();
+  private streamedMessageIds = new Set<string>();
+  private completeEmitted = false;
   private startTime: Date;
 
   constructor(config: SdkSessionConfig) {
@@ -318,7 +320,10 @@ export class SdkSession extends EventEmitter {
       }
     } finally {
       // Ensure 'complete' is always emitted so the web UI doesn't get stuck in "generating"
-      this.emitChatEvent('complete', {});
+      // Only emit if not already emitted by the 'result' message (avoids clearing tokenUsage)
+      if (!this.completeEmitted) {
+        this.emitChatEvent('complete', {});
+      }
       if (this.state !== SdkSessionState.ENDED) {
         this.state = SdkSessionState.ENDED;
         this.emit('end', {
@@ -361,6 +366,15 @@ export class SdkSession extends EventEmitter {
                     : JSON.stringify(resultBlock.content),
                   isError: resultBlock.is_error ?? false,
                 });
+              } else if (block.type === 'text') {
+                const textBlock = block as { type: 'text'; text?: string };
+                if (textBlock.text) {
+                  const msgId = (assistantMsg as { message?: { id?: string } }).message?.id;
+                  // Only emit if this message wasn't already delivered via stream_event
+                  if (!msgId || !this.streamedMessageIds.has(msgId)) {
+                    this.emitChatEvent('text', { content: textBlock.text });
+                  }
+                }
               }
             }
           }
@@ -398,6 +412,7 @@ export class SdkSession extends EventEmitter {
             ? { input: message.usage.input_tokens, output: message.usage.output_tokens }
             : undefined,
         });
+        this.completeEmitted = true;
         break;
 
       default:
@@ -449,6 +464,9 @@ export class SdkSession extends EventEmitter {
       }
 
       case 'message_start':
+        if (event.message?.id) {
+          this.streamedMessageIds.add(event.message.id);
+        }
         this.emitChatEvent('text', { content: '' });
         break;
 


### PR DESCRIPTION
## Summary
- Handle `text` blocks in `routeMessage` assistant case — when SDK sends post-tool response via `assistant` type (not `stream_event`), text was silently dropped
- Track streamed message IDs via `streamedMessageIds` Set to deduplicate against already-streamed content
- Add `completeEmitted` flag to prevent `finally` block from emitting a second `complete` that overwrites `tokenUsage` with `null`

Closes #13

## Test plan
- [ ] Start a chat session and trigger a tool execution (e.g., ask Claude to run a command)
- [ ] Verify text after tool execution appears in the UI
- [ ] Verify token usage panel shows correct values (not cleared to 0)
- [ ] Verify normal streaming (without tool use) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)