### PR TITLE
feat: Docker 部署 Bot 服务

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,24 +1,54 @@
 # CC-Remote 部署与使用说明
 
-本文档面向生产部署与交付，包含：Docker 部署（Server + Web）、Agent 命令行工具安装、以及端到端使用流程。
+本文档面向生产部署与交付，包含：Docker 部署（Server + Web + Bot）、Agent 命令行工具安装、以及端到端使用流程。
 
 ---
 
-## 一、Docker 部署（Server + Web）
+## 一、Docker 部署（Server + Web + Bot）
 
-服务端与 Web 前端打包为单一镜像，一次运行即可对外提供 API 与 Web 界面。
+使用 `docker compose` 一键运行 Server（含 Web 前端）和 Bot 服务。两个容器通过 Docker 内网通信，只需对外暴露一个端口。
 
 ### 1.1 构建镜像
 
 在仓库根目录执行（需已安装 Docker、Docker Compose）：
 
 ```bash
-# 使用 docker compose 构建（推荐）
+# 构建 Server + Bot 镜像
 docker compose build
-
-# 或使用 docker build 指定 Dockerfile
-docker build -f packages/server/Dockerfile -t cc-remote:latest .
 ```
+
+### 1.2 配置环境变量
+
+在仓库根目录创建 `.env` 文件：
+
+```env
+# === Server ===
+JWT_SECRET=your-production-secret-key    # 必改
+JWT_EXPIRES_IN=7d
+CORS_ORIGIN=
+
+# === Bot（按需启用，不配置则不启用对应平台）===
+TELEGRAM_BOT_TOKEN=
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+FEISHU_VERIFICATION_TOKEN=
+FEISHU_ENCRYPT_KEY=
+```
+
+### 1.3 运行容器
+
+```bash
+# 后台运行
+docker compose up -d
+
+# 查看日志
+docker compose logs -f
+
+# 仅查看 Bot 日志
+docker compose logs -f bot
+```
+
+对外只需暴露端口 **3000**（Server + Web），Bot 在内网运行不对外暴露。Bind 流程通过 Server 反向代理 `/api/bind/*` 到 Bot 容器，浏览器无需直连 Bot。
 
 ### 1.2 运行容器
 
@@ -35,45 +65,38 @@ docker compose logs -f
 
 默认将宿主机端口 **3000** 映射到容器内 3000；Web 与 API 均通过 `http://<主机>:3000` 访问。
 
-### 1.3 环境变量（生产必改）
+### 1.4 环境变量
 
-通过环境变量或 `.env` 文件传入（docker compose 会读取当前目录 `.env`）：
+| 变量 | 适用容器 | 说明 | 默认值 |
+|------|----------|------|--------|
+| `JWT_SECRET` | app | JWT 签名密钥，**生产必须修改** | `change-me-in-production` |
+| `JWT_EXPIRES_IN` | app | Token 有效期 | `7d` |
+| `CORS_ORIGIN` | app | 允许的 Web 来源，不设则允许所有 | - |
+| `PORT` | app | 容器内监听端口 | `3000` |
+| `DATABASE_URL` | app | 数据库路径（容器内） | `file:/app/data/cc-remote.db` |
+| `BOT_SERVICE_URL` | app | Bot 服务内网地址 | `http://bot:3001` |
+| `TELEGRAM_BOT_TOKEN` | bot | Telegram Bot Token | - |
+| `FEISHU_APP_ID` | bot | 飞书自建应用 App ID | - |
+| `FEISHU_APP_SECRET` | bot | 飞书自建应用 App Secret | - |
+| `FEISHU_VERIFICATION_TOKEN` | bot | 飞书事件订阅验证 Token | - |
+| `FEISHU_ENCRYPT_KEY` | bot | 飞书事件加密 Key | - |
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `JWT_SECRET` | JWT 签名密钥，**生产必须修改** | `change-me-in-production` |
-| `JWT_EXPIRES_IN` | Token 有效期 | `7d` |
-| `CORS_ORIGIN` | 允许的 Web 来源，不设则允许所有 | - |
-| `PORT` | 容器内监听端口 | `3000` |
-| `DATABASE_URL` | 数据库路径（容器内） | `file:/app/data/cc-remote.db` |
+### 1.5 数据持久化
 
-示例：使用自定义 JWT 并限制 CORS：
+`docker-compose.yml` 中已配置两个 volume：
+- `cc-remote-data`：Server 数据库
+- `bot-data`：Bot 会话数据库
 
-```bash
-export JWT_SECRET=your-production-secret-key
-export CORS_ORIGIN=https://your-domain.com
-docker compose up -d
-```
-
-或在项目根目录创建 `.env`：
-
-```env
-JWT_SECRET=your-production-secret-key
-JWT_EXPIRES_IN=7d
-CORS_ORIGIN=https://your-domain.com
-```
-
-### 1.4 数据持久化
-
-`docker-compose.yml` 中已配置 volume `cc-remote-data`，数据库文件保存在该 volume 中，容器删除后数据仍保留。查看 volume：
+容器删除后数据仍保留。查看 volume：
 
 ```bash
 docker volume inspect cc-remote_cc-remote-data
+docker volume inspect cc-remote_bot-data
 ```
 
-### 1.5 健康检查
+### 1.6 健康检查
 
-容器内提供 HTTP 健康检查：`GET http://localhost:3000/health`。编排或负载均衡可据此判断服务是否就绪。
+Server 容器内提供 HTTP 健康检查：`GET http://localhost:3000/health`。编排或负载均衡可据此判断服务是否就绪。
 
 ---
 
@@ -206,7 +229,11 @@ cc-agent --help
 
 Bot 包（`packages/bot`）可同时运行 Telegram 和飞书 Bot，通过 WebSocket 长连接与 Server 通信。支持在同一进程中运行两个平台。
 
-### 5.1 构建与启动
+部署方式二选一：
+- **Docker**：已在「一、Docker 部署」中包含，在 `.env` 中配置 Bot 环境变量即可
+- **源码**：在独立机器上直接运行（见下方）
+
+### 5.1 源码构建与启动
 
 ```bash
 # 在仓库根目录

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# CC-Remote Server + Web 一键运行
+# CC-Remote Server + Web + Bot 一键运行
 # 构建：docker compose build
 # 运行：docker compose up -d
 # 日志：docker compose logs -f
@@ -19,9 +19,12 @@ services:
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-7d}
       CORS_ORIGIN: ${CORS_ORIGIN:-}
+      BOT_SERVICE_URL: http://bot:3001
     volumes:
       - cc-remote-data:/app/data
     restart: unless-stopped
+    depends_on:
+      - bot
     healthcheck:
       test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));\""]
       interval: 30s
@@ -29,5 +32,25 @@ services:
       retries: 3
       start_period: 15s
 
+  bot:
+    build:
+      context: .
+      dockerfile: packages/bot/Dockerfile
+    image: cc-remote-bot:latest
+    container_name: cc-remote-bot
+    environment:
+      NODE_ENV: production
+      SERVER_URL: http://app:3000
+      BOT_PORT: 3001
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+      FEISHU_APP_ID: ${FEISHU_APP_ID:-}
+      FEISHU_APP_SECRET: ${FEISHU_APP_SECRET:-}
+      FEISHU_VERIFICATION_TOKEN: ${FEISHU_VERIFICATION_TOKEN:-}
+      FEISHU_ENCRYPT_KEY: ${FEISHU_ENCRYPT_KEY:-}
+    volumes:
+      - bot-data:/app/data
+    restart: unless-stopped
+
 volumes:
   cc-remote-data:
+  bot-data:

--- a/packages/bot/Dockerfile
+++ b/packages/bot/Dockerfile
@@ -1,0 +1,65 @@
+# CC-Remote Bot Dockerfile
+# Multi-stage build for Telegram + Feishu bot service
+
+# Stage 1: Build
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+ARG PNPM_VERSION=9.15.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN apk add --no-cache python3 make g++ libc-dev
+
+# Copy workspace config
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml* ./
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/bot/package.json ./packages/bot/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile || pnpm install
+
+# Copy source code
+COPY packages/shared ./packages/shared
+COPY packages/bot ./packages/bot
+COPY tsconfig.base.json ./
+
+# Build shared package first
+WORKDIR /app/packages/shared
+RUN pnpm build
+
+# Build bot
+WORKDIR /app/packages/bot
+RUN pnpm build
+
+# Stage 2: Production
+FROM node:20-bookworm-slim AS production
+
+WORKDIR /app
+
+ARG PNPM_VERSION=9.15.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+# Copy workspace config
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
+
+# Copy shared package
+COPY --from=builder /app/packages/shared/package.json ./packages/shared/
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+
+# Copy bot package
+COPY --from=builder /app/packages/bot/package.json ./packages/bot/
+COPY --from=builder /app/packages/bot/dist ./packages/bot/dist
+
+# Copy node_modules
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/shared/node_modules ./packages/shared/node_modules
+COPY --from=builder /app/packages/bot/node_modules ./packages/bot/node_modules
+
+WORKDIR /app/packages/bot
+
+# Create data directory for SQLite
+RUN mkdir -p /app/data
+
+ENV NODE_ENV=production
+
+CMD ["node", "dist/index.js"]

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -17,4 +17,39 @@ router.use('/machines', machinesRoutes);
 router.use('/machines', gitRoutes);
 router.use('/', uploadRoutes);
 
+/**
+ * Proxy /api/bind/* to Bot service.
+ * In Docker, bot runs in an internal network — browser cannot reach it directly.
+ * Server proxies bind verify/callback requests to the bot container.
+ */
+const BOT_SERVICE_URL = process.env.BOT_SERVICE_URL || 'http://localhost:3001';
+
+// GET /api/bind/verify → Bot service
+router.get('/bind/verify', async (req: Request, res: Response) => {
+  try {
+    const botRes = await fetch(`${BOT_SERVICE_URL}/api/bind/verify${req.url.replace('/api/bind/verify', '')}`);
+    const data = await botRes.json();
+    res.status(botRes.status).json(data);
+  } catch (err) {
+    console.error('[Proxy] Bot service unreachable for bind/verify:', err);
+    res.status(502).json({ error: 'Bot service unreachable' });
+  }
+});
+
+// POST /api/bind/callback → Bot service
+router.post('/bind/callback', async (req: Request, res: Response) => {
+  try {
+    const botRes = await fetch(`${BOT_SERVICE_URL}/api/bind/callback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+    const data = await botRes.json();
+    res.status(botRes.status).json(data);
+  } catch (err) {
+    console.error('[Proxy] Bot service unreachable for bind/callback:', err);
+    res.status(502).json({ error: 'Bot service unreachable' });
+  }
+});
+
 export default router;

--- a/packages/web/src/pages/BindBotPage.tsx
+++ b/packages/web/src/pages/BindBotPage.tsx
@@ -116,10 +116,9 @@ export const BindBotPage: React.FC = () => {
         chat_id: chatId,
       });
 
-      // Notify bot service so it can establish Socket.IO connection
-      const botServiceUrl = import.meta.env.VITE_BOT_SERVICE_URL || 'http://localhost:3001';
+      // Notify bot service via server proxy so it can establish Socket.IO connection
       try {
-        await fetch(`${botServiceUrl}/api/bind/callback`, {
+        await fetch('/api/bind/callback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary

- 新增 `packages/bot/Dockerfile`（多阶段构建），支持 Docker 部署 Bot
- 更新 `docker-compose.yml` 添加 bot 服务（Docker 内网运行，不对外暴露端口）
- Server 新增 `/api/bind/*` 反向代理到 Bot 容器，Bind 流程只需暴露 3000 端口
- 更新 Web `BindBotPage` 调用同域 `/api/bind/callback`，移除 `VITE_BOT_SERVICE_URL` 依赖
- 更新 `DEPLOY.md` 补充 Docker Bot 部署说明

## Architecture

```
Browser → :3000 (Server) → /api/bind/* → proxy → bot:3001 (internal)
         ↕ Socket.IO
Bot ← polling (Telegram) / WebSocket (飞书) → IM Platform
```

## Test plan

- [ ] `docker compose build` 两个镜像构建成功
- [ ] `docker compose up` Server 和 Bot 容器均正常启动
- [ ] 配置 `TELEGRAM_BOT_TOKEN` 后 Bot 能收到 Telegram 消息
- [ ] Bind 流程：浏览器打开 bind 链接 → 登录 → 确认绑定 → 成功（通过 Server 代理）
- [ ] 不配置任何 Bot 环境变量时，Server 正常运行，Bot 容器报错退出（符合预期）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)