### PR TITLE
fix: server proxy bot bind callback instead of direct browser access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 本文件记录项目的所有重要变更。
 
+## [v1.3.0] - 2026-04-26
+
+### Added / 新增
+
+- Bot Docker deployment: dedicated Dockerfile for `packages/bot`, multi-stage Alpine build
+- Bot Docker 镜像部署：为 `packages/bot` 新增独立 Dockerfile，多阶段 Alpine 构建
+- `PUBLIC_URL` env var for bot: separate user-facing bind link URL from internal `SERVER_URL`, fixing Docker deployments where internal URLs are unreachable from user browsers ([#18](https://github.com/markbruce/claude-code-remote/issues/18))
+- Bot 新增 `PUBLIC_URL` 环境变量：将用户可见的绑定链接与内部 `SERVER_URL` 分离，修复 Docker 部署中内部 URL 无法从用户浏览器访问的问题
+- `BOT_SERVICE_URL` env var for server: internal URL for server→bot callbacks
+- 服务端新增 `BOT_SERVICE_URL` 环境变量：用于 server→bot 内部回调
+- HTTP proxy support for Telegram bot via `https-proxy-agent` (works with grammy's node-fetch)
+- Telegram Bot HTTP 代理支持：通过 `https-proxy-agent` 实现（兼容 grammy 的 node-fetch）
+- Bot service in `docker-compose.yml` with health-check dependency on server
+- `docker-compose.yml` 新增 bot 服务，通过 health check 依赖 server
+
+### Changed / 变更
+
+- Bot Docker production stage uses Alpine to match musl native modules (better-sqlite3)
+- Bot Docker 生产阶段改为 Alpine 以匹配 musl 原生模块（better-sqlite3）
+
+### Fixed / 修复
+
+- Fix bot bind links using internal `SERVER_URL` instead of public URL in Docker deployments
+- 修复 Bot 绑定链接在 Docker 部署中使用内部 `SERVER_URL` 而非公网 URL 的问题
+- Fix Telegram bot proxy not working with grammy (switched from global-agent/undici to https-proxy-agent)
+- 修复 Telegram Bot 代理在 grammy 下不生效的问题（从 global-agent/undici 切换为 https-proxy-agent）
+- Remove `docker-compose-nas.yml` from repository (contains personal deployment details)
+- 从仓库中移除 `docker-compose-nas.yml`（包含个人部署信息）
+
 ## [v1.2.0] - 2026-04-19
 
 ### Added / 新增

--- a/README.md
+++ b/README.md
@@ -57,7 +57,23 @@ Claude Code Remote is a lightweight remote development tool that lets you access
 
 ---
 
-## 🆕 v1.2.0 Release Notes
+## 🆕 v1.3.0 Release Notes
+
+feature:
+1. Bot Docker deployment — dedicated Dockerfile with multi-stage Alpine build, CI/CD image publishing via GitHub Actions
+2. `PUBLIC_URL` env var for bot — separate user-facing bind link URL from internal `SERVER_URL`, fixing Docker deployments
+3. `BOT_SERVICE_URL` env var for server — internal URL for server→bot callbacks
+4. HTTP proxy support for Telegram bot via `https-proxy-agent` (compatible with grammy's node-fetch)
+5. Bot service in `docker-compose.yml` with health-check dependency
+
+bugfix:
+1. Fixed bot bind links using internal Docker URL instead of public URL
+2. Fixed Telegram bot proxy not working with grammy (switched from global-agent/undici to https-proxy-agent)
+3. Removed `docker-compose-nas.yml` from repository (contains personal deployment details)
+
+---
+
+## v1.2.0 Release Notes
 
 feature:
 1. Telegram Bot — full-featured bot with InlineKeyboard, streaming output, session management, file/image upload, permission approval

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-remote-agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "bin": {
     "cc-agent": "./dist/index.js"
   },

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-remote-bot",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "bin": {
     "cc-bot": "./dist/index.js"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cc-remote/server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",

--- a/packages/server/src/routes/auth.routes.ts
+++ b/packages/server/src/routes/auth.routes.ts
@@ -448,6 +448,49 @@ router.post('/bind-feishu', authMiddleware, async (req: Request, res: Response) 
 });
 
 /**
+ * POST /api/auth/bind-bot-callback
+ * 代理浏览器到Bot服务的绑定回调（浏览器无法直接访问Docker内部Bot）
+ */
+router.post('/bind-bot-callback', async (req: Request, res: Response) => {
+  try {
+    const { platform_user_id, jwt, refresh_secret } = req.body as {
+      platform_user_id?: string;
+      jwt?: string;
+      refresh_secret?: string;
+    };
+
+    if (!platform_user_id || !jwt) {
+      res.status(HTTP_STATUS.BAD_REQUEST).json({
+        error: '缺少 platform_user_id 或 jwt',
+      });
+      return;
+    }
+
+    const BOT_SERVICE_URL = process.env.BOT_SERVICE_URL || 'http://localhost:3001';
+    const callbackRes = await fetch(`${BOT_SERVICE_URL}/api/bind/callback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform_user_id, jwt, refresh_secret }),
+    });
+
+    if (!callbackRes.ok) {
+      const text = await callbackRes.text();
+      console.error('[Auth] Bot bind callback failed:', callbackRes.status, text);
+      res.status(callbackRes.status).json({ error: 'Bot callback failed', details: text });
+      return;
+    }
+
+    const data = await callbackRes.json();
+    res.status(HTTP_STATUS.OK).json(data);
+  } catch (error) {
+    console.error('[Auth] Bot bind callback proxy error:', error);
+    res.status(HTTP_STATUS.INTERNAL_ERROR).json({
+      error: 'Bot服务不可达',
+    });
+  }
+});
+
+/**
  * POST /api/auth/bot-token
  * Bot服务刷新JWT（无需认证中间件）
  */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-remote-shared",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cc-remote/web",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/web/src/pages/BindBotPage.tsx
+++ b/packages/web/src/pages/BindBotPage.tsx
@@ -116,17 +116,12 @@ export const BindBotPage: React.FC = () => {
         chat_id: chatId,
       });
 
-      // Notify bot service so it can establish Socket.IO connection
-      const botServiceUrl = import.meta.env.VITE_BOT_SERVICE_URL || 'http://localhost:3001';
+      // Notify bot service (via server proxy) so it can establish Socket.IO connection
       try {
-        await fetch(`${botServiceUrl}/api/bind/callback`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            platform_user_id: platformUserId,
-            jwt: result.jwt,
-            refresh_secret: result.refresh_secret,
-          }),
+        await apiClient.post('/api/auth/bind-bot-callback', {
+          platform_user_id: platformUserId,
+          jwt: result.jwt,
+          refresh_secret: result.refresh_secret,
         });
       } catch (e) {
         console.warn('[Bind] Failed to notify bot service:', e);


### PR DESCRIPTION
## Summary
- Add server-side proxy route `POST /api/auth/bind-bot-callback` that forwards bind callbacks to the bot service via `BOT_SERVICE_URL`
- Web frontend now calls the server proxy instead of directly accessing the bot service from the browser
- Eliminates `VITE_BOT_SERVICE_URL` dependency — Docker images are now deployment-agnostic

Closes #20

## Test plan
- [ ] Deploy with Docker Compose (server + bot in separate containers)
- [ ] Send `/start` in Telegram, open bind link in browser
- [ ] Verify bind succeeds and bot session is updated (check bot logs for connection)
- [ ] Verify `/machines` works after binding (no more "Please bind your account first")
- [ ] Test Feishu bind flow as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)